### PR TITLE
Create 0000-MOBILE-Network-Onboarding-Fees

### DIFF
--- a/0000-MOBILE-Network-Onboarding-Fees
+++ b/0000-MOBILE-Network-Onboarding-Fees
@@ -1,0 +1,59 @@
+# HIP XX: MOBILE Network Onboarding Fee
+
+Authors: [Andy Zyvoloski](https://github.com/heatedlime) & @KeithRettig
+Start Date: 6/14/2023
+Category: Technical & Economic
+Original HIP PR: #
+Tracking Issue: #
+Voting Requirements: veMOBILE
+
+##Summary: 
+This proposal suggests the implementation of an onboarding fee for indoor output devices of $10 and outdoor output devices of $20 that join the MOBILE network the day after the passing of this HIP. Output devices are defined in the detailed summary section below.
+
+
+##Motivation:
+As implemented in HIP 51, a DAO Utility Score is used to determine the daily emissions of HNT to each SubDAO treasury. The equation for this calculation is noted below:
+
+$\text{DAO Utility Score} = V \times D \times A$
+Where
+$V = \text{max}(1, veHNT_{DNP})$
+$D = \text{max}(1, \sqrt{\text{DNP DCs burned in USD}})$
+$A = \text{max}(1, \sqrt[4]{\text{DNP Active Device Count} \times \text{DNP Device Activation Fee}})$
+
+At its current rate, the A score in the equation for MOBILE is zero (0), as there currently is not any prescribed onboarding fees for the MOBILE network. The implementation of this HIP would inscribe onboarding fees for output devices which would significantly boost the output of the A score, which in turn, would effectively provide a significant increase to the daily HNT emissions sent to the MOBILE SubDAO treasury.  
+
+This HIP only applies to output devices onboarded the day after the passing of this HIP. Any output devices onboarded prior to the passing of this HIP are already onboarded, and as such, are not required to pay such fee. 
+
+##Stakeholders:
+Stakeholders are all current and future output device deployers on the MOBILE network. 
+
+HNT holders will also benefit with the burning of HNT for each newly onboarded output device.
+
+##Detailed Explanation:
+
+At the passing of this HIP, all outdoor and indoor output devices onboarded to the MOBILE network will be required to pay an onboarding fee, which is paid via data credits. With this HIP, a way to track, manage and burn HNT/data credits for newly onboarded output devices needs to be created by the Helium Foundation. Thus, a way to pay onboarding fees needs to be established before they can be paid. Therefore, any output devices onboarded the day after the passing of this HIP will be required to pay their onboard fee no later than October 31st, 2023. This allows time for the Helium Foundation to create a way to track and manage this process. If any output devices onboarded to the MOBILE network the day after the passing of this HIP do not pay their onboarding fees by October 31st, 2023, their output device will become inactive, and not earn any PoC or data transfer rewards until the fee is paid in full. 
+
+###Definitions
+Output Device - A device that outputs a cellular or wifi signal for End Users to connect to. For example, this would include a CBRS Radio or a Carrier offload Wifi (CoWifi) unit.  
+End User - A device that connects to a cellular or wifi signal, such as a cell phone or mapping device.
+
+
+
+##Alternatives:
+One alternative is to do nothing, and keep onboarding fees as zero (0). However, this would hinder the daily HNT emissions to the MOBILE SubDAO treasury since the A score would remain zero (0). 
+
+Another alternative is to change the way the A score is calculated to benefit the HNT emissions of the MOBILE Network; however, this would require a vote with veHNT instead of veMOBILE. 
+
+
+##Unresolved Question:
+None
+
+
+##Deployment Impact:
+Output deployers will now need to pay onboarding fees for any newly onboarded output devices after the implementation of this HIP.
+
+The Helium Foundation will need to create a way to track and manage output device onboards and ensure fees paid for output devices prior to the October 31, 2023 deadline. Further, the foundation will need to ensure that the day after the passing of this HIP that the A score for the MOBILE SubDAO is correctly updated to reflect the total amount of indoor and outdoor output devices, as well as their associated fees for the MOBILE SubDAO.
+
+
+##Success Metrics:
+The primary success metric will be greater daily HNT emissions to the MOBILE SubDAO treasury. 


### PR DESCRIPTION
This proposal suggests the implementation of an onboarding fee for indoor output devices of $10 and outdoor output devices of $20 that join the MOBILE network after the passing of this HIP.

It's imperative that this HIP is put for discussion and vote ASAP, as every day we get closer to HNT halving will result in less HNT distributed to the MOBILE SubDAO treasury. 